### PR TITLE
helm -> helm_linux

### DIFF
--- a/repos.bzl
+++ b/repos.bzl
@@ -30,7 +30,7 @@ def helm_repositories(version = "2.17.0"):
 
     if "helm_linux" not in native.existing_rules():
         http_archive(
-            name = "helm",
+            name = "helm_linux",
             sha256 = _VERSION_SHAS[version]["linux"],
             urls = ["https://storage.googleapis.com/kubernetes-helm/helm-v{}-linux-amd64.tar.gz".format(version)],
             build_file = "@com_github_tmc_rules_helm//:helm.BUILD",


### PR DESCRIPTION
I noticed that in d7a23fcc a bunch of references to helm
were switched to helm_linux, but not this one. I think this
may be related to the errors like

```
ERROR: /home/ethan/.cache/bazel/_bazel_ethan/3df2138fe5f0935007d667eb063e1dbe/external/com_github_tmc_rules_helm/BUILD.bazel:1:10: no such package '@helm_linux//': The repository '@helm_linux' could not be resolved and referenced by '@com_github_tmc_rules_helm//:helm'
```

that I'm seeing in my linux VM during development. I'm not really sure
how to check though, so this is a bit of a YOLO PR. @martinxsliu
hopefully this is more obvious to you.